### PR TITLE
Refactor for tests

### DIFF
--- a/samples/native/src/commonMain/kotlin/runner.kt
+++ b/samples/native/src/commonMain/kotlin/runner.kt
@@ -30,4 +30,20 @@ fun runSecureRandom() {
 
         println("$i: $bytes")
     }
+
+    listOf(
+        500,
+        5000,
+        50000,
+    ).forEach { i ->
+
+        try {
+            sRandom.nextBytesOf(5000)
+        } catch (e: SecRandomCopyException) {
+            e.printStackTrace()
+            return
+        }
+
+        println("$i: omitted (success)")
+    }
 }

--- a/secure-random/build.gradle.kts
+++ b/secure-random/build.gradle.kts
@@ -85,6 +85,12 @@ kmpConfiguration {
                     }
                 }
             }
+
+            sourceSetLinuxX64Test {
+                dependencies {
+                    implementation(depsTest.kotlin.coroutines)
+                }
+            }
         }
     )
 }

--- a/secure-random/src/commonTest/kotlin/io/matthewnelson/component/secure/random/SecureRandomUnitTest.kt
+++ b/secure-random/src/commonTest/kotlin/io/matthewnelson/component/secure/random/SecureRandomUnitTest.kt
@@ -62,12 +62,14 @@ class SecureRandomUnitTest {
             webLimit * 2,
         )
 
+        val sRandom = SecureRandom()
+
         for (size in sizes) {
             val bytes = ByteArray(size)
             val emptyByte = bytes[0]
 
             try {
-                SecureRandom().nextBytesCopyTo(bytes)
+                sRandom.nextBytesCopyTo(bytes)
             } catch (e: SecRandomCopyException) {
                 // TODO: Remove once implementations are all complete
                 if (e.message == "SYS_getrandom not supported") {

--- a/secure-random/src/commonTest/kotlin/io/matthewnelson/component/secure/random/SecureRandomUnitTest.kt
+++ b/secure-random/src/commonTest/kotlin/io/matthewnelson/component/secure/random/SecureRandomUnitTest.kt
@@ -88,8 +88,10 @@ class SecureRandomUnitTest {
             // filled. Must adjust our limit depending on size to mitigate
             // false positives.
             val emptyLimit = when {
+                size < 10 -> 0.5f
                 size < 200 -> 0.04F
                 size < 1000 -> 0.03F
+                size < 10000 -> 0.01F
                 else -> 0.0075F
             }.let { pctErr ->
                 (size * pctErr).toInt()

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/component/secure/random/internal/GetRandom.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/component/secure/random/internal/GetRandom.kt
@@ -17,9 +17,15 @@
 
 package io.matthewnelson.component.secure.random.internal
 
-import kotlinx.cinterop.*
-import platform.posix.*
-import kotlin.native.concurrent.AtomicInt
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.UnsafeNumber
+import kotlinx.cinterop.convert
+import platform.posix.ENOSYS
+import platform.posix.EPERM
+import platform.posix.size_t
+import platform.posix.syscall
+import platform.posix.u_int
 
 /**
  * Helper for:
@@ -31,7 +37,7 @@ import kotlin.native.concurrent.AtomicInt
  *
  * https://man7.org/linux/man-pages/man2/getrandom.2.html
  * */
-internal class GetRandom private constructor() {
+internal class GetRandom private constructor(): SecRandomPoller() {
 
     internal companion object {
         private const val NO_FLAGS: UInt = 0U
@@ -40,72 +46,25 @@ internal class GetRandom private constructor() {
         // https://docs.piston.rs/dev_menu/libc/constant.GRND_NONBLOCK.html
         private const val GRND_NONBLOCK: UInt = 0x0001U
 
-        private const val TRUE = 1
-        private const val FALSE = 0
-        private const val UNCHECKED = -1
-
         internal val instance = GetRandom()
     }
 
-    private val hasGetRandom = AtomicInt(UNCHECKED)
-
     internal fun isAvailable(): Boolean {
-        when (hasGetRandom.value) {
-            FALSE -> return false
-            TRUE -> return true
-            else -> {
-                val buf = ByteArray(1)
-                val lock = buf.hashCode()
-
-                try {
-                    return checkGetRandom(buf, lock)
-                } finally {
-                    // If for some reason value wasn't updated to t/f
-                    // release the lock by setting it back to UNCHECKED
-                    hasGetRandom.compareAndSet(lock, UNCHECKED)
-                }
-            }
-        }
-    }
-
-    private fun checkGetRandom(buf: ByteArray, lock: Int): Boolean {
-        // acquire lock
-        while (true) {
-            when (hasGetRandom.value) {
-                FALSE -> return false
-                TRUE -> return true
-                else -> {
-                    if (hasGetRandom.compareAndSet(UNCHECKED, lock)) {
-                        break
-                    }
-                }
-            }
-        }
-
-        // Check non-blocking with 1 byte
-        val result = buf.usePinned { pinned ->
+        return pollingResult { buf, size ->
             @OptIn(UnsafeNumber::class)
-            getrandom(pinned.addressOf(0), buf.size.toULong().convert(), GRND_NONBLOCK)
-        }
+            val result = getrandom(buf, size.toULong().convert(), GRND_NONBLOCK)
 
-        // Set + return t/f
-        if (result < 0) {
-            @Suppress("LiftReturnOrAssignment")
-            when (result) {
-                ENOSYS, // No kernel support
-                EPERM, // Blocked by seccomp
-                -> {
-                    hasGetRandom.compareAndSet(lock, FALSE)
-                    return false
+            if (result < 0) {
+                when (result) {
+                    ENOSYS, // No kernel support
+                    EPERM, // Blocked by seccomp
+                    -> false
+                    else
+                    -> true
                 }
-                else -> {
-                    hasGetRandom.compareAndSet(lock, TRUE)
-                    return true
-                }
+            } else {
+                true
             }
-        } else {
-            hasGetRandom.compareAndSet(lock, TRUE)
-            return true
         }
     }
 

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/component/secure/random/internal/GetRandom.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/component/secure/random/internal/GetRandom.kt
@@ -28,11 +28,13 @@ import kotlin.native.concurrent.AtomicInt
  *
  * Must always check that [isAvailable] returns true before
  * calling [getrandom].
+ *
+ * https://man7.org/linux/man-pages/man2/getrandom.2.html
  * */
 internal class GetRandom private constructor() {
 
     internal companion object {
-        const val NO_FLAGS: UInt = 0U
+        private const val NO_FLAGS: UInt = 0U
         // https://docs.piston.rs/dev_menu/libc/constant.SYS_getrandom.html
         private const val SYS_getrandom: Long = 318L
         // https://docs.piston.rs/dev_menu/libc/constant.GRND_NONBLOCK.html
@@ -109,14 +111,15 @@ internal class GetRandom private constructor() {
 
     /**
      * Must always call [isAvailable] beforehand.
-     *
-     * https://man7.org/linux/man-pages/man2/getrandom.2.html
      * */
     @OptIn(UnsafeNumber::class)
-    internal fun getrandom(
+    internal fun getrandom(buf: CPointer<ByteVar>, buflen: size_t): Int = getrandom(buf, buflen, NO_FLAGS)
+
+    @OptIn(UnsafeNumber::class)
+    private fun getrandom(
         buf: CPointer<ByteVar>,
         buflen: size_t,
-        flags: u_int = NO_FLAGS,
+        flags: u_int,
     ): Int {
         @Suppress("RemoveRedundantCallsOfConversionMethods")
         return syscall(SYS_getrandom.convert(), buf, buflen, flags).toInt()

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/component/secure/random/internal/SecRandomDelegate.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/component/secure/random/internal/SecRandomDelegate.kt
@@ -51,11 +51,11 @@ internal actual abstract class SecRandomDelegate private actual constructor() {
         }
     }
 
+    // TODO: Add fallback (Issue #25)
     private object SecRandomDelegateURandom: SecRandomDelegate() {
 
         @Throws(SecRandomCopyException::class)
         override fun nextBytesCopyTo(size: Int, ptrBytes: CPointer<ByteVar>) {
-            // TODO: Add fallback (Issue #25)
             throw SecRandomCopyException("SYS_getrandom not supported")
         }
     }

--- a/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/component/secure/random/internal/SecRandomPoller.kt
+++ b/secure-random/src/linuxAndroidMain/kotlin/io/matthewnelson/component/secure/random/internal/SecRandomPoller.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.component.secure.random.internal
+
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlin.native.concurrent.AtomicInt
+
+internal abstract class SecRandomPoller {
+
+    private companion object {
+        private const val TRUE = 1
+        private const val FALSE = 0
+        private const val UNKNOWN = -1
+    }
+
+    private val result = AtomicInt(UNKNOWN)
+
+    protected fun pollingResult(poll: (buf: CPointer<ByteVar>, size: Int) -> Boolean): Boolean {
+        when (result.value) {
+            TRUE -> return true
+            FALSE -> return false
+            else -> {
+                val buf = ByteArray(1)
+                val lock = buf.hashCode()
+
+                try {
+                    return startPolling(buf, lock, poll)
+                } finally {
+                    // If for some reason value wasn't updated to t/f,
+                    // ensure the lock is reset back to UNKNOWN so that
+                    // it can be obtained again.
+                    result.compareAndSet(lock, UNKNOWN)
+                }
+            }
+        }
+    }
+
+    private fun startPolling(
+        buf: ByteArray,
+        lock: Int,
+        poll: (buf: CPointer<ByteVar>, size: Int) -> Boolean
+    ): Boolean {
+        while (true) {
+            when (result.value) {
+                TRUE -> return true
+                FALSE -> return false
+                else -> {
+                    if (result.compareAndSet(UNKNOWN, lock)) {
+                        break
+                    }
+                }
+            }
+        }
+
+        val result: Boolean = buf.usePinned { pinned ->
+            poll.invoke(pinned.addressOf(0), buf.size)
+        }
+
+        this.result.compareAndSet(lock, if (result) TRUE else FALSE)
+
+        return result
+    }
+}

--- a/secure-random/src/linuxX64Test/kotlin/io/matthewnelson/component/secure/random/SecRandomPollerUnitTest.kt
+++ b/secure-random/src/linuxX64Test/kotlin/io/matthewnelson/component/secure/random/SecRandomPollerUnitTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.component.secure.random
+
+import io.matthewnelson.component.secure.random.internal.SecRandomPoller
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runTest
+import kotlin.native.concurrent.AtomicInt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SecRandomPollerUnitTest {
+
+    private class TestPoller: SecRandomPoller() {
+        private val lock = Mutex(locked = true)
+        val count = AtomicInt(0)
+        val calledBeforeCompletion = AtomicInt(0)
+
+        suspend fun pollFailIfInvoked() {
+            val calledBefore = count.value == 0
+
+            lock.withLock {  }
+
+            pollingResult { _, _ ->
+                throw IllegalArgumentException("Polling was allowed to be invoked multiple times")
+            }
+
+            if (calledBefore) {
+                calledBeforeCompletion.increment()
+            }
+        }
+
+        fun pollTrigger() {
+            pollingResult { _, _ ->
+
+                lock.unlock()
+
+                runBlocking {
+                    delay(500L)
+                }
+
+                true
+            }
+
+            count.increment()
+        }
+    }
+
+    @Test
+    fun givenPollingResult_whenMultipleInvocations_thenOnlyPollsOnce() = runTest {
+        val poller = TestPoller()
+
+        val jobs = mutableListOf<Job>()
+
+        val repeatTimes = 100
+        repeat(repeatTimes) {
+
+            launch {
+                poller.pollFailIfInvoked()
+            }.let { job ->
+                jobs.add(job)
+            }
+        }
+
+        delay(500L)
+
+        launch(Dispatchers.Default) {
+            poller.pollTrigger()
+        }.join()
+
+        for (job in jobs) {
+            job.join()
+        }
+
+
+        assertEquals(1, poller.count.value)
+        assertEquals(repeatTimes, poller.calledBeforeCompletion.value)
+    }
+}
+


### PR DESCRIPTION
Refactors a few things to make testing easier on the polling. Wanted to ensure that locks were behaving properly (only being invoked once no matter how hard it was being hammered by other callers.

Cleans up some things and puts codebase in better spot for #25 